### PR TITLE
Feature/use jenkins marketplace for aws codepipeline plugin

### DIFF
--- a/cookbooks/jenkins-config/recipes/default.rb
+++ b/cookbooks/jenkins-config/recipes/default.rb
@@ -1,9 +1,21 @@
-if ['rhel', 'amazon'].include?(node['platform'])
+if ['rhel'].include?(node['platform_family'])
+  # XXX should this instead do security updates instead of full
+  # system updates?
   execute 'yum upgrade -y'
+  # default repository should be the Long-Term Support release
+  # https://wiki.jenkins-ci.org/display/JENKINS/LTS+Release+Line
+  default['jenkins']['master']['repository'] = 'http://pkg.jenkins-ci.org/redhat-stable'
+  default['jenkins']['master']['repository_key'] = 'http://pkg.jenkins-ci.org/redhat-stable/jenkins-ci.org.key'
 end
-if ['ubuntu'].include?(node['platform'])
+if ['debian'].include?(node['platform'])
+  # XXX should this instead do security updates instead of full
+  # system updates?
   execute 'aptitude update'
   execute 'aptitude upgrade -y'
+  # default repository should be the Long-Term Support release
+  # https://wiki.jenkins-ci.org/display/JENKINS/LTS+Release+Line
+  default['jenkins']['master']['repository'] = 'http://pkg.jenkins-ci.org/debian-stable'
+  default['jenkins']['master']['repository_key'] = 'http://pkg.jenkins-ci.org/debian-stable/jenkins-ci.org.key'
 end
 
 include_recipe 'jenkins-config::jenkins-yum-prereqs'

--- a/cookbooks/jenkins-config/recipes/default.rb
+++ b/cookbooks/jenkins-config/recipes/default.rb
@@ -4,8 +4,8 @@ if ['rhel'].include?(node['platform_family'])
   execute 'yum upgrade -y'
   # default repository should be the Long-Term Support release
   # https://wiki.jenkins-ci.org/display/JENKINS/LTS+Release+Line
-  default['jenkins']['master']['repository'] = 'http://pkg.jenkins-ci.org/redhat-stable'
-  default['jenkins']['master']['repository_key'] = 'http://pkg.jenkins-ci.org/redhat-stable/jenkins-ci.org.key'
+  node.default['jenkins']['master']['repository'] = 'http://pkg.jenkins-ci.org/redhat-stable'
+  node.default['jenkins']['master']['repository_key'] = 'http://pkg.jenkins-ci.org/redhat-stable/jenkins-ci.org.key'
 end
 if ['debian'].include?(node['platform'])
   # XXX should this instead do security updates instead of full
@@ -14,8 +14,8 @@ if ['debian'].include?(node['platform'])
   execute 'aptitude upgrade -y'
   # default repository should be the Long-Term Support release
   # https://wiki.jenkins-ci.org/display/JENKINS/LTS+Release+Line
-  default['jenkins']['master']['repository'] = 'http://pkg.jenkins-ci.org/debian-stable'
-  default['jenkins']['master']['repository_key'] = 'http://pkg.jenkins-ci.org/debian-stable/jenkins-ci.org.key'
+  node.default['jenkins']['master']['repository'] = 'http://pkg.jenkins-ci.org/debian-stable'
+  node.default['jenkins']['master']['repository_key'] = 'http://pkg.jenkins-ci.org/debian-stable/jenkins-ci.org.key'
 end
 
 include_recipe 'jenkins-config::jenkins-yum-prereqs'

--- a/cookbooks/jenkins-config/recipes/jenkins-plugins.rb
+++ b/cookbooks/jenkins-config/recipes/jenkins-plugins.rb
@@ -6,11 +6,4 @@ jenkins_plugin 'token-macro'
 jenkins_plugin 'ruby-runtime'
 jenkins_plugin 'ansicolor'
 jenkins_plugin 'delivery-pipeline-plugin'
-
-remote_file '/var/lib/jenkins/plugins/aws-codepipeline-plugin-for-jenkins.hpi' do
-  source 'https://github.com/awslabs/aws-codepipeline-plugin-for-jenkins/blob/f8f8482782b6e45283c1d5cb4267df071be41402/dist/aws-codepipeline-plugin-for-jenkins.hpi?raw=true'
-  owner 'jenkins'
-  group 'jenkins'
-  mode '0755'
-  action :create
-end
+jenkins_plugin 'aws-codepipeline'


### PR DESCRIPTION
This PR defaults the Jenkins install to using the LTS repositories as well as uses Jenkins Marketplace for the aws-codepipeline plugin

As a bonus, it uses platform_family for determining apt-get vice yum, instead of platform (this is the preferred pattern with cookbooks, it seems)
